### PR TITLE
Add RHEL 9 default var files for ipaclient, ipareplica, ipaserver

### DIFF
--- a/roles/ipaclient/vars/RedHat-9.yml
+++ b/roles/ipaclient/vars/RedHat-9.yml
@@ -1,0 +1,3 @@
+# defaults file for ipaclient
+# vars/RedHat-9.yml
+ipaclient_packages: [ "ipa-client" ]

--- a/roles/ipareplica/vars/RedHat-9.yml
+++ b/roles/ipareplica/vars/RedHat-9.yml
@@ -1,0 +1,5 @@
+# defaults file for ipareplica
+# vars/RedHat-9.yml
+ipareplica_packages: [ "ipa-server" ]
+ipareplica_packages_dns: [ "ipa-server-dns" ]
+ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]

--- a/roles/ipaserver/vars/RedHat-9.yml
+++ b/roles/ipaserver/vars/RedHat-9.yml
@@ -1,0 +1,5 @@
+# defaults file for ipaserver
+# vars/RedHat-9.yml
+ipareplica_packages: [ "ipa-server" ]
+ipareplica_packages_dns: [ "ipa-server-dns" ]
+ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]


### PR DESCRIPTION
Add default var files for RHEL 9 to ipaclient, ipareplica, and ipaserver